### PR TITLE
Fix codeblock content missing issue

### DIFF
--- a/source/js/code-enhance.js
+++ b/source/js/code-enhance.js
@@ -90,8 +90,8 @@ function enhanceCodeBlocks() {
         const gutterLines = gutter ? Array.from(gutter.querySelectorAll('.line')).map(line => line.textContent) : [];
         
         // 获取代码内容
-        const code = table.querySelector('.code pre code');
-        const codeContent = code ? code.innerHTML : '';
+        const code = table.querySelector('.code pre');
+        const codeContent = code ? Array.from(code.querySelectorAll('.line')).map(line => line.textContent).join('\n') : '';
         
         // 创建外部容器来包裹标题栏和代码块
         const container = document.createElement('div');
@@ -145,8 +145,10 @@ function enhanceCodeBlocks() {
         
         // 创建代码内容区域 - 修改这部分，使用正确的结构
         const codePre = document.createElement('pre');
+        const codeElement = document.createElement('code');
+        codePre.appendChild(codeElement);
         codePre.className = `code-content hljs ${language}`;
-        codePre.innerHTML = codeContent;
+        codeElement.innerHTML = codeContent;
           // 创建包含两个pre的容器
         const codeBlockWrapper = document.createElement('div');
         codeBlockWrapper.className = 'code-pre-wrapper';


### PR DESCRIPTION
Hi @B143KC47, thanks for creating this theme, it's very helpful. I just found out the code block cannot be rendered correctly and I made some change locally to fix it.

**To reproduce the issue:**
1. Use hexo to init a new folder
2. git clone the vsc4t repo into theme
3. Setup the configuration and run `hexo serve`
4. Then you might find the code block is empty

To verify the fix, you can follow the same procedure above.