### PR TITLE
Update mermaid block style and add set up instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ If you find this theme useful, please consider giving it a star on GitHub! Your 
 - 🔧 **Easy configuration** - Simple and intuitive setup
 - 📂 **Explorer-like sidebar** - Intuitive navigation for categories and tags
 - 🌐 **Multi-language support** - 12 languages available out of the box
+- 🧜🏻‍♀️ **Mermaid diagrams support** - Integrated support for Mermaid diagrams
 
 ## 📊 Star History
 
@@ -289,6 +290,13 @@ highlight:
   enable: true
   line_number: true
   auto_detect: true
+```
+
+## Mermaid Diagrams Support
+The theme support mermaid diagrams, you need to install the following plugin to make sure it can render properly:
+
+```bash
+npm install hexo-filter-mermaid-diagrams
 ```
 
 ## Search Configuration

--- a/source/css/code-custom.css
+++ b/source/css/code-custom.css
@@ -115,7 +115,7 @@ pre:not(.line-numbers-pre):not(.code-content) {
 }
 
 /* 添加代码类型标记到普通代码块 */
-pre:not(.line-numbers-pre):not(.code-content)::before {
+pre:not(.line-numbers-pre):not(.code-content):not(.mermaid.enhanced)::before {
   content: "code";
   position: absolute;
   top: 0;
@@ -127,6 +127,32 @@ pre:not(.line-numbers-pre):not(.code-content)::before {
   border-bottom-left-radius: 6px;
   font-family: 'JetBrains Mono', monospace;
   font-weight: 500;
+}
+
+/* Enhanced Mermaid block label */
+pre.mermaid.enhanced::before {
+  content: "mermaid";
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: linear-gradient(135deg, #2c2c2c, #3a3a3a);
+  color: #a0a0a0;
+  padding: 4px 10px;
+  font-size: 12px;
+  font-family: 'JetBrains Mono', 'Segoe UI', sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  border-bottom-left-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+  transition: all 0.3s ease;
+}
+
+pre.mermaid.enhanced:hover::before {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.3);
+  background: linear-gradient(135deg, #3a3a3a, #2c2c2c);
+  color: #b8b8b8;
 }
 
 /* 滚动指示效果 */


### PR DESCRIPTION
Update the tag for Mermaid block, also add instructions for mermaid diagram. Currently it require using the plugin to format some DOM. We can consider remove this dependency in the future. 

<img width="875" alt="Screenshot 2025-04-19 at 3 26 58 PM" src="https://github.com/user-attachments/assets/5fb0d876-fd5a-4539-b792-67ede812f937" />